### PR TITLE
Handles missing error after shell lookup

### DIFF
--- a/linux/pkg/server.go
+++ b/linux/pkg/server.go
@@ -687,6 +687,7 @@ func (s *server) execute(command *cakeagent.CakeAgent_ExecuteRequest_ExecuteComm
 
 			if shell, err = exec.LookPath(shell); err != nil {
 				shell = "/bin/sh"
+				err = nil
 			}
 			cmd = exec.CommandContext(ctx, shell, "-i", "-l")
 		} else if exc := command.GetCommand(); exc != nil {


### PR DESCRIPTION
The error variable was not being reset to nil after setting the shell to /bin/sh, causing incorrect behavior if the initial shell lookup failed. This commit resets the error to nil to prevent unintended errors.
