### PR TITLE
Enhance network details with CIDR and robust MAC address handling

### DIFF
--- a/darwin/Sources/CakeAgent/InfosHandler.swift
+++ b/darwin/Sources/CakeAgent/InfosHandler.swift
@@ -88,13 +88,20 @@ struct InfosHandler {
 					}
 
 					if addrFamily == UInt8(AF_LINK) && name != "lo0" {
-						networkInfo.macAddress = withUnsafeBytes(of: interface.ifa_addr.pointee) { ptr in
-							var macAddress = [CChar](repeating: 0, count: 128)
-							var sockaddr_dl = ptr.load(as: sockaddr_dl.self)
-
-							link_addr(&macAddress, &sockaddr_dl)
-
-							return String(cString: macAddress)
+						if let sdlPtr = UnsafePointer<sockaddr_dl>(OpaquePointer(interface.ifa_addr)) {
+							let sdl = sdlPtr.pointee
+							let nameLen = Int(sdl.sdl_nlen)
+							let addrLen = Int(sdl.sdl_alen)
+							
+							let macAddress: String = withUnsafeBytes(of: sdl) { rawBuffer in
+								// sdl_data starts after the fixed header fields; compute its base offset
+								let sdlDataOffset = MemoryLayout.offset(of: \sockaddr_dl.sdl_data) ?? 0
+								let macStart = sdlDataOffset + nameLen
+								guard macStart + addrLen <= rawBuffer.count else { return "" }
+								let macBytes = rawBuffer[macStart..<(macStart + addrLen)]
+								return macBytes.map { String(format: "%02x", $0) }.joined(separator: ":")
+							}
+							networkInfo.macAddress = macAddress
 						}
 					}
 
@@ -109,7 +116,51 @@ struct InfosHandler {
 								&hostname, socklen_t(hostname.count),
 								nil, socklen_t(0), NI_NUMERICHOST)
 					
-					let address = String(cString: hostname)
+                    // Build numeric address string
+                    let baseAddress = String(cString: hostname)
+
+                    // Compute CIDR prefix length from netmask
+                    var prefixLength: Int = -1
+                    if let netmaskPtr = interface.ifa_netmask {
+                        let family = interface.ifa_addr.pointee.sa_family
+                        if family == UInt8(AF_INET) {
+                            // IPv4 netmask
+                            let nm = UnsafeRawPointer(netmaskPtr).assumingMemoryBound(to: sockaddr_in.self).pointee
+                            let mask = nm.sin_addr.s_addr
+                            // Count bits set to 1 in network byte order
+                            var m = UInt32(bigEndian: mask)
+                            var count = 0
+                            while m != 0 {
+                                count += Int(m & 1)
+                                m >>= 1
+                            }
+                            prefixLength = count
+                        } else if family == UInt8(AF_INET6) {
+                            // IPv6 netmask
+                            let nm6 = UnsafeRawPointer(netmaskPtr).assumingMemoryBound(to: sockaddr_in6.self).pointee
+                            let addr = nm6.sin6_addr
+                            // Count bits in 16 bytes
+                            withUnsafeBytes(of: addr) { bytes in
+                                var cnt = 0
+                                for b in bytes {
+                                    var v = b
+                                    while v != 0 {
+                                        cnt += Int(v & 1)
+                                        v >>= 1
+                                    }
+                                }
+                                prefixLength = cnt
+                            }
+                        }
+                    }
+
+                    // Append CIDR if computed; otherwise keep base address
+                    let address: String
+                    if prefixLength >= 0 {
+                        address = "\(baseAddress)/\(prefixLength)"
+                    } else {
+                        address = baseAddress
+                    }
 					
 					if address.contains("%") == false {
 						networkInfo.addresses.append(address)

--- a/darwin/Sources/CakeAgent/InfosHandler.swift
+++ b/darwin/Sources/CakeAgent/InfosHandler.swift
@@ -116,51 +116,51 @@ struct InfosHandler {
 								&hostname, socklen_t(hostname.count),
 								nil, socklen_t(0), NI_NUMERICHOST)
 					
-                    // Build numeric address string
-                    let baseAddress = String(cString: hostname)
+					// Build numeric address string
+					let baseAddress = String(cString: hostname)
 
-                    // Compute CIDR prefix length from netmask
-                    var prefixLength: Int = -1
-                    if let netmaskPtr = interface.ifa_netmask {
-                        let family = interface.ifa_addr.pointee.sa_family
-                        if family == UInt8(AF_INET) {
-                            // IPv4 netmask
-                            let nm = UnsafeRawPointer(netmaskPtr).assumingMemoryBound(to: sockaddr_in.self).pointee
-                            let mask = nm.sin_addr.s_addr
-                            // Count bits set to 1 in network byte order
-                            var m = UInt32(bigEndian: mask)
-                            var count = 0
-                            while m != 0 {
-                                count += Int(m & 1)
-                                m >>= 1
-                            }
-                            prefixLength = count
-                        } else if family == UInt8(AF_INET6) {
-                            // IPv6 netmask
-                            let nm6 = UnsafeRawPointer(netmaskPtr).assumingMemoryBound(to: sockaddr_in6.self).pointee
-                            let addr = nm6.sin6_addr
-                            // Count bits in 16 bytes
-                            withUnsafeBytes(of: addr) { bytes in
-                                var cnt = 0
-                                for b in bytes {
-                                    var v = b
-                                    while v != 0 {
-                                        cnt += Int(v & 1)
-                                        v >>= 1
-                                    }
-                                }
-                                prefixLength = cnt
-                            }
-                        }
-                    }
+					// Compute CIDR prefix length from netmask
+					var prefixLength: Int = -1
+					if let netmaskPtr = interface.ifa_netmask {
+						let family = interface.ifa_addr.pointee.sa_family
+						if family == UInt8(AF_INET) {
+							// IPv4 netmask
+							let nm = UnsafeRawPointer(netmaskPtr).assumingMemoryBound(to: sockaddr_in.self).pointee
+							let mask = nm.sin_addr.s_addr
+							// Count bits set to 1 in network byte order
+							var m = UInt32(bigEndian: mask)
+							var count = 0
+							while m != 0 {
+								count += Int(m & 1)
+								m >>= 1
+							}
+							prefixLength = count
+						} else if family == UInt8(AF_INET6) {
+							// IPv6 netmask
+							let nm6 = UnsafeRawPointer(netmaskPtr).assumingMemoryBound(to: sockaddr_in6.self).pointee
+							let addr = nm6.sin6_addr
+							// Count bits in 16 bytes
+							withUnsafeBytes(of: addr) { bytes in
+								var cnt = 0
+								for b in bytes {
+									var v = b
+									while v != 0 {
+										cnt += Int(v & 1)
+										v >>= 1
+									}
+								}
+								prefixLength = cnt
+							}
+						}
+					}
 
-                    // Append CIDR if computed; otherwise keep base address
-                    let address: String
-                    if prefixLength >= 0 {
-                        address = "\(baseAddress)/\(prefixLength)"
-                    } else {
-                        address = baseAddress
-                    }
+					// Append CIDR if computed; otherwise keep base address
+					let address: String
+					if prefixLength >= 0 {
+						address = "\(baseAddress)/\(prefixLength)"
+					} else {
+						address = baseAddress
+					}
 					
 					if address.contains("%") == false {
 						networkInfo.addresses.append(address)

--- a/darwin/Sources/CakeAgent/InfosHandler.swift
+++ b/darwin/Sources/CakeAgent/InfosHandler.swift
@@ -86,27 +86,28 @@ struct InfosHandler {
 					networkInfo = CakeAgent.InfoReply.NetworkInfo.with {
 						$0.interface = name
 					}
-
-					if addrFamily == UInt8(AF_LINK) && name != "lo0" {
-						if let sdlPtr = UnsafePointer<sockaddr_dl>(OpaquePointer(interface.ifa_addr)) {
-							let sdl = sdlPtr.pointee
-							let nameLen = Int(sdl.sdl_nlen)
-							let addrLen = Int(sdl.sdl_alen)
-							
-							let macAddress: String = withUnsafeBytes(of: sdl) { rawBuffer in
-								// sdl_data starts after the fixed header fields; compute its base offset
-								let sdlDataOffset = MemoryLayout.offset(of: \sockaddr_dl.sdl_data) ?? 0
-								let macStart = sdlDataOffset + nameLen
-								guard macStart + addrLen <= rawBuffer.count else { return "" }
-								let macBytes = rawBuffer[macStart..<(macStart + addrLen)]
-								return macBytes.map { String(format: "%02x", $0) }.joined(separator: ":")
-							}
-							networkInfo.macAddress = macAddress
-						}
-					}
-
-					networkInfos[name] = networkInfo
 				}
+
+				if addrFamily == UInt8(AF_LINK) && name != "lo0" {
+					if let sdlPtr = UnsafePointer<sockaddr_dl>(OpaquePointer(interface.ifa_addr)) {
+						let sdl = sdlPtr.pointee
+						let nameLen = Int(sdl.sdl_nlen)
+						let addrLen = Int(sdl.sdl_alen)
+						
+						let macAddress: String = withUnsafeBytes(of: sdl) { rawBuffer in
+							// sdl_data starts after the fixed header fields; compute its base offset
+							let sdlDataOffset = MemoryLayout.offset(of: \sockaddr_dl.sdl_data) ?? 0
+							let macStart = sdlDataOffset + nameLen
+							guard macStart + addrLen <= rawBuffer.count else { return "" }
+							let macBytes = rawBuffer[macStart..<(macStart + addrLen)]
+							return macBytes.map { String(format: "%02x", $0) }.joined(separator: ":")
+						}
+
+						networkInfo.macAddress = macAddress
+						networkInfos[name] = networkInfo
+					}
+				}
+
 
 				if (addrFamily == UInt8(AF_INET) || addrFamily == UInt8(AF_INET6)) && name != "lo0" {
 					var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))

--- a/darwin/Sources/CakeAgentLib/CakeAgentHelper.swift
+++ b/darwin/Sources/CakeAgentLib/CakeAgentHelper.swift
@@ -528,7 +528,7 @@ public struct InfoReply: Sendable, Codable {
 		self.uptime = info.uptime
 		self.cpuCount = info.cpuCount
 		self.attachedNetworks = info.networkInfos.map { AttachedNetwork($0) }
-		self.ipaddresses = info.networkInfos.flatMap { $0.addresses }
+		self.ipaddresses = info.networkInfos.flatMap { $0.addresses.map { $0.split(separator: "/").first.map(String.init) ?? $0 } }
 		self.osname = info.osname
 		self.hostname = info.hostname
 		self.release = info.release

--- a/linux/pkg/server.go
+++ b/linux/pkg/server.go
@@ -396,12 +396,14 @@ func (s *server) IpAddresses() ([]*cakeagent.CakeAgent_InfoReply_NetworkInfo, er
 						switch v := addr.(type) {
 						case *net.IPNet:
 							ip = v.IP
+							if ip != nil && !ip.IsLoopback() && ip.IsGlobalUnicast() {
+								inf.Addresses = append(inf.Addresses, v.String())
+							}
 						case *net.IPAddr:
 							ip = v.IP
-						}
-
-						if ip != nil && !ip.IsLoopback() && ip.IsGlobalUnicast() {
-							inf.Addresses = append(inf.Addresses, ip.String())
+							if ip != nil && !ip.IsLoopback() && ip.IsGlobalUnicast() {
+								inf.Addresses = append(inf.Addresses, ip.String())
+							}
 						}
 					}
 


### PR DESCRIPTION
This change improves the completeness and accuracy of network information reported by the agent.

- On Darwin, MAC address retrieval is made more robust, and IP addresses now include their CIDR prefix for a more complete network configuration.
- On Linux, IP addresses derived from `net.IPNet` consistently include their CIDR.
- The `ipaddresses` field in the reply is adjusted to contain only the raw IP address, while `attachedNetworks` retains the full CIDR information for detailed context.
