### PR TITLE
Enhances Port Forwarding Filter & IP Resolution

### DIFF
--- a/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
+++ b/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
@@ -122,8 +122,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 	internal let queue = DispatchQueue(label: "CakeAgentPortForwarder")
 	internal var status: Status = .idle
 	internal let remoteHost: String
-
-	public var discardedPort: Set<PortFilter> = [.individual(22), .individual(53), .individual(68)]
+	internal let discardedPort: Set<PortFilter>
 
 	public enum Status: Int {
 		case idle = 0
@@ -133,13 +132,14 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 		case stopped = 4
 	}
 
-	public init(group: EventLoopGroup, cakeAgentClient: CakeAgentClient, bindAddress: [String], remoteHost: String, forwardedPorts: [TunnelAttachement], ttl: Int = 5) throws {
+	public init(group: EventLoopGroup, cakeAgentClient: CakeAgentClient, bindAddress: [String], remoteHost: String, forwardedPorts: [TunnelAttachement], discardedPort: Set<PortFilter> = [.individual(22), .individual(53), .individual(68)], ttl: Int = 5) throws {
 		let mappedPorts = forwardedPorts.filter { $0.unixDomain == nil }.compactMap { $0.mappedPort }
 
 		self.bindAddress = bindAddress
 		self.remoteHost = remoteHost
 		self.ttl = ttl
 		self.cakeAgentClient = cakeAgentClient
+		self.discardedPort = discardedPort
 		self.logger = Logger("CakedPortForwarder")
 
 		try super.init(group: group, remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddresses: bindAddress, udpConnectionTTL: ttl)

--- a/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
+++ b/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
@@ -79,14 +79,14 @@ extension SocketAddress {
 
 public enum PortFilter: Sendable, Hashable {
 	case individual(Int32)
-	case range(Int32, Int32)
+	case range(Range<Int32>)
 
 	public func contains(_ port: Int32) -> Bool {
 		switch self {
 		case .individual(let p):
 			return port == p
-		case .range(let start, let end):
-			return port >= start && port <= end
+		case .range(let range):
+			return range.contains(port)
 		}
 	}
 }

--- a/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
+++ b/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
@@ -77,6 +77,20 @@ extension SocketAddress {
 
 }
 
+public enum PortFilter: Sendable, Hashable {
+	case individual(Int32)
+	case range(Int32, Int32)
+
+	public func contains(_ port: Int32) -> Bool {
+		switch self {
+		case .individual(let p):
+			return port == p
+		case .range(let start, let end):
+			return port >= start && port <= end
+		}
+	}
+}
+
 struct ForwardedSocketAddress: Sendable, Equatable, CustomStringConvertible {
 	var description: String {
 		"\(proto.rawValue)://\(addr):\(port)"
@@ -107,6 +121,9 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 	internal var eventChannel: Channel? = nil
 	internal let queue = DispatchQueue(label: "CakeAgentPortForwarder")
 	internal var status: Status = .idle
+	internal let remoteHost: String
+
+	public var discardedPort: Set<PortFilter> = [.individual(22), .individual(53), .individual(68)]
 
 	public enum Status: Int {
 		case idle = 0
@@ -120,6 +137,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 		let mappedPorts = forwardedPorts.filter { $0.unixDomain == nil }.compactMap { $0.mappedPort }
 
 		self.bindAddress = bindAddress
+		self.remoteHost = remoteHost
 		self.ttl = ttl
 		self.cakeAgentClient = cakeAgentClient
 		self.logger = Logger("CakedPortForwarder")
@@ -135,7 +153,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 	}
 
 	public func handleEvent(event: CakeAgent.TunnelPortForwardEvent.ForwardEvent) {
-		let discardedPort: [Int32] = [22, 53, 68]
+		let discardedPort = self.discardedPort
 
 		let addedPorts = event.addedPorts.reduce(into: [ForwardedSocketAddress]()) { addedPorts, port in
 			let portIP = (port.ip.isEmpty || port.ip == "0.0.0.0") ? self.remoteHost : port.ip
@@ -143,7 +161,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 			if let remoteAddress = try? SocketAddress(ipAddress: portIP, port: Int(port.port)) {
 				let forward = ForwardedSocketAddress(proto: port.protocol, addr: portIP, port: Int(port.port))
 
-				if discardedPort.contains(port.port) {
+				if discardedPort.contains(where: { $0.contains(port.port) }) {
 					self.logger.info("Discard dynamic port forwarding: \(forward.description) (discarded port)")
 				} else if addedPorts.first(where: { $0.port == port.port && $0.addr == portIP }) != nil {
 					self.logger.info("Already binded dynamic port forwarding: \(forward.description)")
@@ -164,7 +182,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 		addedPorts.forEach { forward in
 			self.bindAddress.forEach { bindAddress in
 				let bindAddress: SocketAddress = try! SocketAddress.makeAddress("tcp://\(bindAddress):\(forward.port)")
-				let remoteAddress = try! SocketAddress(ipAddress: forward.addr, port: forward.port)
+				let remoteAddress =  try! SocketAddress(ipAddress: forward.addr, port: forward.port)
 
 				if bindAddress.protocol == remoteAddress.protocol {
 					self.logger.info("Add dynamic port forwarding: \(bindAddress) -> \(remoteAddress)")
@@ -184,7 +202,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 		}
 
 		let removedPorts = event.removedPorts.compactMap { port in
-			if discardedPort.contains(port.port) == false {
+			if !discardedPort.contains(where: { $0.contains(port.port) }) {
 				let forward: ForwardedSocketAddress = ForwardedSocketAddress(proto: port.protocol, addr: port.ip, port: Int(port.port))
 
 				if self.dynamicPorts.contains(forward) {

--- a/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
+++ b/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
@@ -156,7 +156,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 		let discardedPort = self.discardedPort
 
 		let addedPorts = event.addedPorts.reduce(into: [ForwardedSocketAddress]()) { addedPorts, port in
-			let portIP = (port.ip.isEmpty || port.ip == "0.0.0.0") ? self.remoteHost : port.ip
+			let portIP = (port.ip.isEmpty || port.ip == "0.0.0.0" || port.ip == "::") ? self.remoteHost : port.ip
 
 			if let remoteAddress = try? SocketAddress(ipAddress: portIP, port: Int(port.port)) {
 				let forward = ForwardedSocketAddress(proto: port.protocol, addr: portIP, port: Int(port.port))
@@ -203,7 +203,8 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 
 		let removedPorts = event.removedPorts.compactMap { port in
 			if !discardedPort.contains(where: { $0.contains(port.port) }) {
-				let forward: ForwardedSocketAddress = ForwardedSocketAddress(proto: port.protocol, addr: port.ip, port: Int(port.port))
+				let portIP = (port.ip.isEmpty || port.ip == "0.0.0.0" || port.ip == "::") ? self.remoteHost : port.ip
+				let forward: ForwardedSocketAddress = ForwardedSocketAddress(proto: port.protocol, addr: portIP, port: Int(port.port))
 
 				if self.dynamicPorts.contains(forward) {
 					self.logger.info("Will remove dynamic port forwarding: \(forward.description)")

--- a/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
+++ b/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
@@ -136,13 +136,16 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 
 	public func handleEvent(event: CakeAgent.TunnelPortForwardEvent.ForwardEvent) {
 		let discardedPort: [Int32] = [22, 53, 68]
+
 		let addedPorts = event.addedPorts.reduce(into: [ForwardedSocketAddress]()) { addedPorts, port in
-			if let remoteAddress = try? SocketAddress(ipAddress: port.ip, port: Int(port.port)) {
-				let forward = ForwardedSocketAddress(proto: port.protocol, addr: port.ip, port: Int(port.port))
+			let portIP = (port.ip.isEmpty || port.ip == "0.0.0.0") ? self.remoteHost : port.ip
+
+			if let remoteAddress = try? SocketAddress(ipAddress: portIP, port: Int(port.port)) {
+				let forward = ForwardedSocketAddress(proto: port.protocol, addr: portIP, port: Int(port.port))
 
 				if discardedPort.contains(port.port) {
 					self.logger.info("Discard dynamic port forwarding: \(forward.description) (discarded port)")
-				} else if addedPorts.first(where: { $0.port == port.port && $0.addr == port.ip }) != nil {
+				} else if addedPorts.first(where: { $0.port == port.port && $0.addr == portIP }) != nil {
 					self.logger.info("Already binded dynamic port forwarding: \(forward.description)")
 				} else {
 					if remoteAddress.isLoopback || remoteAddress.isLinkLocal {
@@ -154,7 +157,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 					}
 				}
 			} else {
-				self.logger.warn("Invalid dynamic port forwarding: \(port.ip):\(port.port)")
+				self.logger.warn("Invalid dynamic port forwarding: \(portIP):\(port.port)")
 			}
 		}
 

--- a/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
+++ b/darwin/Sources/CakeAgentLib/Tunnel/CakeAgentPortForwarder.swift
@@ -164,7 +164,7 @@ public class CakeAgentPortForwarder: PortForwarder, @unchecked Sendable {
 				if discardedPort.contains(where: { $0.contains(port.port) }) {
 					self.logger.info("Discard dynamic port forwarding: \(forward.description) (discarded port)")
 				} else if addedPorts.first(where: { $0.port == port.port && $0.addr == portIP }) != nil {
-					self.logger.info("Already binded dynamic port forwarding: \(forward.description)")
+					self.logger.info("Already bound dynamic port forwarding: \(forward.description)")
 				} else {
 					if remoteAddress.isLoopback || remoteAddress.isLinkLocal {
 						self.logger.info("Discard dynamic port forwarding: \(forward.description) (loopback/link local)")


### PR DESCRIPTION
Adds a new `PortFilter` enum to allow discarding dynamic port forwarding based on individual ports or port ranges. This provides more flexible control over which ports are automatically ignored by the forwarder.

Resolves an issue where dynamic port forwarding events received with unspecified IP addresses (e.g., "0.0.0.0" or empty) would fail. The forwarder now correctly defaults to the configured remote host in these scenarios, ensuring proper connection establishment.