### PR TITLE
Ensure accurate tilde expansion using real home directory

### DIFF
--- a/darwin/Sources/CakeAgentLib/CakeAgentClientOptions.swift
+++ b/darwin/Sources/CakeAgentLib/CakeAgentClientOptions.swift
@@ -10,16 +10,6 @@ public typealias CakeAgentClient = Cakeagent_CakeAgentServiceNIOClient
 public typealias CakeAgentServiceClientInterceptorFactoryProtocol = Cakeagent_CakeAgentServiceClientInterceptorFactoryProtocol
 public typealias CakeAgentServiceClientMetadata = Cakeagent_CakeAgentServiceClientMetadata
 
-extension String {
-	var expandingTildeInPath: String {
-		if self.hasPrefix("~") {
-			return (self as NSString).expandingTildeInPath
-		}
-		
-		return self
-	}
-}
-
 public struct CakeAgentClientOptions: ParsableArguments {
 
 	@Option(help: "Connection timeout in seconds")

--- a/darwin/Sources/CakeAgentLib/CakeAgentCommon.swift
+++ b/darwin/Sources/CakeAgentLib/CakeAgentCommon.swift
@@ -14,18 +14,33 @@ extension FileManager {
 
 extension String {
 	var expandingTildeInPath: String {
-		if self.hasPrefix("~") {
-			let home = FileManager.realHomeDirectoryForCurrentUser.path(percentEncoded: false)
-			let name = self.dropFirst(1)
-
-			if name.isEmpty {
-				return home
-			}
-
-			return home + name
+		guard self.hasPrefix("~") else {
+			return self
 		}
-		
-		return self
+
+		let currentHome = FileManager.realHomeDirectoryForCurrentUser.path(percentEncoded: false)
+
+		// "~" or "~/..."
+		if self == "~" {
+			return currentHome
+		}
+
+		if self.hasPrefix("~/") {
+			return currentHome + String(self.dropFirst())
+		}
+
+		// "~user" or "~user/..."
+		let afterTilde = self.index(after: self.startIndex)
+		let slashIndex = self[afterTilde...].firstIndex(of: "/")
+		let userEnd = slashIndex ?? self.endIndex
+		let user = String(self[afterTilde..<userEnd])
+		let rest = slashIndex.map { String(self[$0...]) } ?? ""
+
+		guard let pw = getpwnam(user), let dir = pw.pointee.pw_dir else {
+			return self
+		}
+
+		return String(cString: dir) + rest
 	}
 
 	public func toSocketAddress() throws -> SocketAddress {

--- a/darwin/Sources/CakeAgentLib/CakeAgentCommon.swift
+++ b/darwin/Sources/CakeAgentLib/CakeAgentCommon.swift
@@ -2,7 +2,32 @@ import Foundation
 import ArgumentParser
 import NIO
 
+extension FileManager {
+	public static var realHomeDirectoryForCurrentUser: URL {
+		let home: String = getpwuid(getuid()).flatMap { pw in
+			pw.pointee.pw_dir.map { String(cString: $0) }
+		} ?? NSHomeDirectory()
+
+		return URL(fileURLWithPath: home, isDirectory: true)
+	}
+}
+
 extension String {
+	var expandingTildeInPath: String {
+		if self.hasPrefix("~") {
+			let home = FileManager.realHomeDirectoryForCurrentUser.path(percentEncoded: false)
+			let name = self.dropFirst(1)
+
+			if name.isEmpty {
+				return home
+			}
+
+			return home + name
+		}
+		
+		return self
+	}
+
 	public func toSocketAddress() throws -> SocketAddress {
 		let socketAddress: SocketAddress
 


### PR DESCRIPTION
The previous `expandingTildeInPath` implementation relied on `NSHomeDirectory()`, which could return an inaccurate home directory in certain execution contexts (e.g., daemons or sandboxed environments).

This change introduces a more robust method to determine the real home directory using `getpwuid(getuid())`. This ensures that `~` consistently expands to the actual user's home directory, providing correct path resolution regardless of the execution environment.
