### PR TITLE
Fix socket path handling to support paths containing spaces

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,13 @@ let package = Package(
 		.library(name: "CakeAgentLib", targets: ["CakeAgentLib"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0"),
+		.package(url: "https://github.com/Fred78290/swift-argument-parser", revision: "d554955e8c280aa4c4a05a039a968f0205656e77"),
 		.package(url: "https://github.com/grpc/grpc-swift.git", revision: "5770e231585cb68388a6ae37ce36c4d8dbd46d90"),
 		.package(url: "https://github.com/apple/swift-nio.git", from: "2.92.1"),
 		.package(url: "https://github.com/apple/swift-protobuf.git", from: "1.33.3"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.8.0"),
 		.package(url: "https://github.com/groue/Semaphore", from: "0.0.8"),
-		.package(url: "https://github.com/Fred78290/swift-nio-portforwarding.git", .upToNextMajor(from: "0.2.9")),
+		.package(url: "https://github.com/Fred78290/swift-nio-portforwarding.git", .upToNextMajor(from: "0.2.11")),
 		.package(url: "https://github.com/cfilipov/TextTable", branch: "master"),
 	],
 	targets: [

--- a/darwin/Sources/CakeAgent/Commands/Run.swift
+++ b/darwin/Sources/CakeAgent/Commands/Run.swift
@@ -85,7 +85,7 @@ struct Run: ParsableCommand {
 
 				target = ConnectionTarget.vsockAddress(VsockAddress(cid: cid, port: .init(listeningAddress.port ?? 5000)))
 			} else if listeningAddress.scheme == "unix" {
-				target = ConnectionTarget.unixDomainSocket(listeningAddress.path())
+				target = ConnectionTarget.unixDomainSocket(listeningAddress.path(percentEncoded: false))
 			} else if listeningAddress.scheme == "tcp" {
 				target = ConnectionTarget.hostAndPort(listeningAddress.host ?? "127.0.0.1", listeningAddress.port ?? 5000)
 			} else {

--- a/darwin/Sources/CakeAgent/Commands/Service.swift
+++ b/darwin/Sources/CakeAgent/Commands/Service.swift
@@ -109,7 +109,7 @@ struct Service: ParsableCommand {
 
 				let serviceURL = URL(fileURLWithPath: "/etc/systemd/system/\(cakerSignature).service")
 
-				if FileManager.default.fileExists(atPath: serviceURL.path) {
+				if FileManager.default.fileExists(atPath: serviceURL.path(percentEncoded: false)) {
 					throw InstallError.failedToWriteLaunchAgentPlist("File already exists")
 				}
 
@@ -127,7 +127,7 @@ struct Service: ParsableCommand {
 			func install(arguments: [String]) throws {
 				let agentURL = URL(fileURLWithPath: "/Library/LaunchDaemons/\(cakerSignature).plist")
 
-				if FileManager.default.fileExists(atPath: agentURL.path) {
+				if FileManager.default.fileExists(atPath: agentURL.path(percentEncoded: false)) {
 					throw InstallError.failedToWriteLaunchAgentPlist("File already exists")
 				}
 

--- a/darwin/Sources/CakeAgentLib/CakeAgentCommon.swift
+++ b/darwin/Sources/CakeAgentLib/CakeAgentCommon.swift
@@ -11,7 +11,7 @@ extension String {
 		}
 
 		if u.scheme == "unix" || u.isFileURL {
-			socketAddress = try .init(unixDomainSocketPath: u.path)
+			socketAddress = try .init(unixDomainSocketPath: u.path(percentEncoded: false))
 		} else {
 			socketAddress = try .init(ipAddress: u.host ?? "127.0.0.1", port: Int(u.port ?? 0))
 		}

--- a/darwin/Sources/CakeAgentLib/CakeAgentHelper.swift
+++ b/darwin/Sources/CakeAgentLib/CakeAgentHelper.swift
@@ -929,7 +929,7 @@ public struct CakeAgentHelper: Sendable {
 		let target: ConnectionTarget
 		
 		if listeningAddress.scheme == "unix" || listeningAddress.isFileURL {
-			target = ConnectionTarget.unixDomainSocket(listeningAddress.path())
+			target = ConnectionTarget.unixDomainSocket(listeningAddress.path(percentEncoded: false))
 		} else if listeningAddress.scheme == "tcp" {
 			target = ConnectionTarget.hostAndPort(listeningAddress.host ?? "127.0.0.1", listeningAddress.port ?? 5000)
 		} else {

--- a/darwin/Sources/TestAgent/Root.swift
+++ b/darwin/Sources/TestAgent/Root.swift
@@ -119,7 +119,7 @@ struct Root: AsyncParsableCommand {
 
 			cakeHomeDir.append(path: ".cakeagent.sock")
 
-			return "unix://\(cakeHomeDir.absoluteURL.path())"
+			return "unix://\(cakeHomeDir.absoluteURL.path(percentEncoded: false))"
 		}
 	}
 


### PR DESCRIPTION
Replace `.path()` with `.path(percentEncoded: false)` when resolving Unix domain socket paths and file URLs, ensuring percent-encoded characters (e.g., spaces as `%20`) are decoded before use.
